### PR TITLE
Adds an option to specify additional matching group(s) in the alias string

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ exports.resolve = (modulePath, sourceFile, config) => {
       const re = new RegExp(`^${map[i][0]}($|/)`);
       const match = modulePath.match(re);
       if (match) {
-        resolvePath = modulePath.replace(match[0], `${map[i][1]}${match[1]}`);
+        resolvePath = modulePath.replace(match[0], `${map[i][1]}${match.slice(1).join('')}`);
         break;
       }
     }


### PR DESCRIPTION
Handling the case of presence of some additional matching group(s) in the alias string, e.g. you should be able to write a pattern
    `[["~(\\w+)", "./src/"]]`
instead of specifying each alias explicitly
    `[["~redux", "./src/redux"], ["~config", "./src/config"]]`